### PR TITLE
Reduce bundle size by externalizing React and ReactDOM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,24 +25,28 @@
   "author": "web3space",
   "license": "MIT",
   "dependencies": {
+    "polished": "^4.2.2",
+    "react-device-detect": "^2.2.2",
+    "react-qr-code": "^2.0.7",
+    "styled-components": "^5.3.5"
+  },
+  "devDependencies": {
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/styled-components": "^5.1.25",
-    "polished": "^4.2.2",
     "react": "^18.2.0",
-    "react-device-detect": "^2.2.2",
     "react-dom": "^18.2.0",
-    "react-qr-code": "^2.0.7",
-    "styled-components": "^5.3.5",
+    "react-scripts": "5.0.1",
     "ts-loader": "^9.3.1",
     "typescript": "^4.4.2",
     "url-loader": "^4.1.1",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0"
   },
-  "devDependencies": {
-    "react-scripts": "5.0.1"
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "eslintConfig": {
     "extends": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,4 +34,8 @@ module.exports = {
       },
     ],
   },
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM'
+  },
 };


### PR DESCRIPTION
- reduce bundle size by 136KB (~30%)
- divide dependencies into dependencies, devDependencies and peerDependencies